### PR TITLE
Review loot configuration settings

### DIFF
--- a/AscEnd/AscEnd.au3
+++ b/AscEnd/AscEnd.au3
@@ -1,6 +1,7 @@
 #RequireAdmin
 #include "../../API/_GwAu3.au3"
 #include "GwAu3_AddOns.au3"
+#include "LootSettings.au3"
 #include "../../API/Plugins/UtilityAI/_UtilityAI.au3"
 
 #Region Declarations

--- a/AscEnd/GUI.au3
+++ b/AscEnd/GUI.au3
@@ -181,16 +181,13 @@ Next
 GUICtrlCreateGroup("", -99, -99, 1, 1)
 
 ; CheckBox Options
-; Survivor Mode, 19 Stop, Purple & Collectors
+; Survivor Mode, 19 Stop
 Global Const $OPT_SURVIVOR  = 1
-Global Const $OPT_PURPLE    = 2
-Global Const $OPT_COLLECTOR = 4
 Global Const $OPT_19STOP    = 8
 
-
-$Loot = GUICtrlCreateGroup("Keep", 16, 129, 85, 57)
-$GUI_CBPurple = GUICtrlCreateCheckbox("Purple?", 24, 145, 73, 17, BitOR($GUI_SS_DEFAULT_CHECKBOX,$BS_LEFT))
-$GUI_CBCollector = GUICtrlCreateCheckbox("Collectors?", 24, 162, 73, 17, BitOR($GUI_SS_DEFAULT_CHECKBOX,$BS_LEFT))
+$Group4 = GUICtrlCreateGroup("Loot Config", 16, 129, 86, 57)
+$GUISettingsButton = GUICtrlCreateButton("Settings", 31, 146, 57, 33)
+GUICtrlSetOnEvent($GUISettingsButton, "GuiButtonHandler")
 GUICtrlCreateGroup("", -99, -99, 1, 1)
 
 $Config = GUICtrlCreateGroup("Config", 108, 129, 101, 57)
@@ -203,14 +200,6 @@ Func GetSelectedOptions()
 
     If GUICtrlRead($GUI_CBSurvivor) = $GUI_CHECKED Then
         $options = BitOR($options, $OPT_SURVIVOR)
-    EndIf
-
-    If GUICtrlRead($GUI_CBPurple) = $GUI_CHECKED Then
-        $options = BitOR($options, $OPT_PURPLE)
-    EndIf
-
-    If GUICtrlRead($GUI_CBCollector) = $GUI_CHECKED Then
-        $options = BitOR($options, $OPT_COLLECTOR)
     EndIf
 
     If GUICtrlRead($GUI_CB19Stop) = $GUI_CHECKED Then
@@ -347,16 +336,11 @@ Func GuiButtonHandler()
                 GUICtrlSetState($GUIStartButton, $GUI_DISABLE)
                 GUICtrlSetState($FarmCombo, $GUI_DISABLE)
                 GUICtrlSetState($GUI_CBSurvivor, $GUI_DISABLE)
-                GUICtrlSetState($GUI_CBPurple, $GUI_DISABLE)
-                GUICtrlSetState($GUI_CBCollector, $GUI_DISABLE)
                 GUICtrlSetState($GUI_CB19Stop, $GUI_DISABLE)
+                GUICtrlSetState($GUISettingsButton, $GUI_DISABLE)
 
                 $Survivor = BitAND($options, $OPT_SURVIVOR)
                 LogStatus($Survivor ? "Survivor mode enabled." : "Survivor mode disabled.")
-                $Purple = BitAND($options, $OPT_PURPLE)
-                LogStatus($Purple ? "Keeping Purples." : "Discarding Purples.")
-                $Collector = BitAND($options, $OPT_COLLECTOR)
-                LogStatus($Collector ? "Keeping Collectors materials." : "Discarding Collectors materials.")
                 $_19Stop = BitAND($options, $OPT_19STOP)
                 LogStatus($_19Stop ? "Stopping at level 19, only applicable to hamnet." : "Sending to level 20.")
 
@@ -367,9 +351,8 @@ Func GuiButtonHandler()
             ElseIf $BotRunning Then
                 GUICtrlSetState($FarmCombo, $GUI_ENABLE)
                 GUICtrlSetState($GUI_CBSurvivor, $GUI_ENABLE)
-                GUICtrlSetState($GUI_CBPurple, $GUI_ENABLE)
-                GUICtrlSetState($GUI_CBCollector, $GUI_ENABLE)
                 GUICtrlSetState($GUI_CB19Stop, $GUI_ENABLE)
+                GUICtrlSetState($GUISettingsButton, $GUI_ENABLE)
                 
                 GUICTrlSetState($GUIStartButton, $GUI_DISABLE)
                 GUICtrlSetData($GUIStartButton, "Pausing...")
@@ -380,6 +363,9 @@ Func GuiButtonHandler()
         Case $GUIRefreshButton
             GUICtrlSetData($GUINameCombo, "")
             GUICtrlSetData($GUINameCombo, Scanner_GetLoggedCharNames())
+
+        Case $GUISettingsButton
+            ShowLootSettings()
 
         Case $GUI_EVENT_CLOSE
             Exit
@@ -449,9 +435,8 @@ Func ResetStart()
     GUICtrlSetState($GUIStartButton, $GUI_ENABLE)
     GUICtrlSetState($FarmCombo, $GUI_ENABLE)
     GUICtrlSetState($GUI_CBSurvivor, $GUI_ENABLE)
-    GUICtrlSetState($GUI_CBPurple, $GUI_ENABLE)
-    GUICtrlSetState($GUI_CBCollector, $GUI_ENABLE)
     GUICtrlSetState($GUI_CB19Stop, $GUI_ENABLE)
+    GUICtrlSetState($GUISettingsButton, $GUI_ENABLE)
     GUICtrlSetData($GUIStartButton, "Start")
     $CharrBossPickup = True
     $hasBonus = False

--- a/AscEnd/GwAu3_AddOns.au3
+++ b/AscEnd/GwAu3_AddOns.au3
@@ -1035,7 +1035,7 @@ Func CharrCasterFilter($aAgentPtr)
     If Agent_GetAgentInfo($aAgentPtr, 'IsDead') > 0 Then Return False
 
     Local $ModelID = Agent_GetAgentInfo($aAgentPtr, 'PlayerNumber')
-    Local $CharrModelIDs[8] = [1452, 1450, 1451, 1453, 1649, 1639, 1659, 1641] ; 4 Bosses + Shaman, Chaot, Hunter, Ashen Claw
+    Local $CharrModelIDs[8] = [1452, 1450, 1451, 1453, 1649, 1638, 1659, 1641] ; 4 Bosses + Shaman, Chaot, Hunter, Ashen Claw
     Local $IsCharr = False
     For $i = 0 To UBound($CharrModelIDs) - 1
         If $ModelID == $CharrModelIDs[$i] Then
@@ -2202,7 +2202,7 @@ Func Sell($BagIndex)
     For $ii = 1 To Item_GetBagInfo($BagPtr, "Slots")
         $aItemPtr = Item_GetItemBySlot($BagIndex, $ii)
         If Item_GetItemInfoByPtr($aItemPtr, "ItemID") = 0 Then ContinueLoop
-        Local $sellable = CanSell($aItemPtr)
+        Local $sellable = CanSellEx($aItemPtr)
         Sleep(500)
         If $sellable Then
             Merchant_SellItem($aItemPtr)

--- a/AscEnd/GwAu3_AddOns.au3
+++ b/AscEnd/GwAu3_AddOns.au3
@@ -2297,12 +2297,12 @@ Func CanSell($aItem)
   
     Switch $IsPurple
     Case True
-       Return Not $Purple ; Is purple
+       Return Not GetLootPickup("Purple") ; Is purple
     EndSwitch
 
     Switch $IsPreCollectable
     Case True
-       Return Not $Collector ; Is pre-collectable
+       Return Not GetLootPickup("Collector") ; Is pre-collectable
     EndSwitch
 
     Switch $IsSpecial
@@ -4241,8 +4241,6 @@ Global $TimerToKill = 0
 
 Global $Survivor = False
 Global $_19Stop = False
-Global $Collector = False
-Global $Purple = False
 Global $spawn[2] = [0, 0]
 Global $hasBonus = False
 Global $CharrBossFarm = False

--- a/AscEnd/LootSettings.au3
+++ b/AscEnd/LootSettings.au3
@@ -6,7 +6,12 @@
 ; =========================
 ; GLOBAL VARIABLES
 ; =========================
-Global $gLootTypes[3] = ["Purple", "Collector", "Mod"]
+Global $gLootTypes[24] = [ _
+    "Gold", "Purple", "Blue", _
+    "Collectors", "Baked Husks", "Charr Carvings", "Dull Carapaces", "Enchanted Lodestones", "Gargoyle Skulls", "Grawl Necklaces", "Icy Lodestones", "Red Iris", "Skale Fins", "Skeletal Limbs", "Spider Legs", "Unnatural Seeds", "Worn Belts", _
+    "Dye", "Black Dye", "White Dye", _
+    "Pcons", "Charr Bags", "Charr Salvage Kit" _
+]
 Global $gTreeItems = ObjCreate("Scripting.Dictionary")
 Global $LootRules = ObjCreate("Scripting.Dictionary")
 Global $gLootIniFile = @ScriptDir & "\LootConfig.ini"
@@ -27,19 +32,19 @@ Func ShowLootSettings()
     EndIf
     
     ; Create the GUI
-    $hLootGUI = GUICreate("Loot Configuration", 320, 430)
+    $hLootGUI = GUICreate("AscEnd", 313, 288, 253, 250, -1, BitOR($WS_EX_TRANSPARENT,$WS_EX_WINDOWEDGE))
     GUISetFont(9, 400, 0, "Tahoma")
     GUISetBkColor(0xF0F0F0) ; Standard grey background
     
-    GUICtrlCreateLabel("Select items to pick up and their actions:", 15, 15, 290, 20)
-    GUICtrlSetFont(-1, 9, 600, 0, "Tahoma") ; Bold header
+    $Group3 = GUICtrlCreateGroup("Loot Configuration", 8, 7, 296, 273, -1, $WS_EX_TRANSPARENT)
+    $btnApply = GUICtrlCreateButton("Apply", 64, 239, 89, 28)
+    $btnClose = GUICtrlCreateButton("Close", 160, 239, 89, 28)
     
-    ; TVS_NOTOOLTIPS disables tooltips, removing TVS_SHOWSELALWAYS makes selection less prominent
-    $tree = GUICtrlCreateTreeView(15, 40, 290, 330, _
-        BitOR($TVS_CHECKBOXES, $TVS_HASBUTTONS, $TVS_LINESATROOT, $TVS_DISABLEDRAGDROP, $TVS_NOTOOLTIPS))
+    $tree = GUICtrlCreateTreeView(32, 32, 249, 193, _
+        BitOR($GUI_SS_DEFAULT_TREEVIEW, $TVS_CHECKBOXES, $TVS_SINGLEEXPAND, $TVS_FULLROWSELECT, $WS_HSCROLL, $TVS_DISABLEDRAGDROP, $TVS_NOTOOLTIPS), _
+        $WS_EX_CLIENTEDGE)
     
-    $btnApply = GUICtrlCreateButton("Save & Apply", 125, 385, 95, 30)
-    $btnClose = GUICtrlCreateButton("Close", 230, 385, 75, 30)
+    GUICtrlCreateGroup("", -99, -99, 1, 1)
     
     ; Register OnEvent mode handlers if the main GUI uses OnEvent mode
     GUISetOnEvent($GUI_EVENT_CLOSE, "HandleLootSettingsMsg", $hLootGUI)
@@ -60,24 +65,44 @@ EndFunc
 ; BUILD TREE
 ; =========================
 Func BuildLootTree()
+    Local $parent = 0
+    Local $collectorsNode = 0
+    Local $dyeNode = 0
+    
     For $i = 0 To UBound($gLootTypes) - 1
         Local $type = $gLootTypes[$i]
         
-        ; Parent node = Loot type
-        Local $parent = GUICtrlCreateTreeViewItem($type, $tree)
+        ; Determine the correct parent node
+        Switch $type
+            Case "Collectors", "Dye", "Gold", "Purple", "Blue", "Pcons", "Charr Bags", "Charr Salvage Kit"
+                $parent = GUICtrlCreateTreeViewItem($type, $tree)
+                
+                ; Save references to specific category parents
+                If $type = "Collectors" Then $collectorsNode = $parent
+                If $type = "Dye" Then $dyeNode = $parent
+                
+            Case "Black Dye", "White Dye"
+                $parent = GUICtrlCreateTreeViewItem($type, $dyeNode)
+                
+            Case Else ; E.g. "Baked Husks", "Red Iris", etc.
+                $parent = GUICtrlCreateTreeViewItem($type, $collectorsNode)
+        EndSwitch
         
-        ; Children = Actions (radio style)
-        Local $keep    = GUICtrlCreateTreeViewItem("Keep", $parent)
-        Local $sell    = GUICtrlCreateTreeViewItem("Sell", $parent)
+        ; Keep/Sell options for items that support actions
+        If $type <> "Pcons" And $type <> "Charr Bags" And $type <> "Charr Salvage Kit" Then
+            Local $keep = GUICtrlCreateTreeViewItem("Keep", $parent)
+            Local $sell = GUICtrlCreateTreeViewItem("Sell", $parent)
+            
+            $gTreeItems($type & "_Keep") = $keep
+            $gTreeItems($type & "_Sell") = $sell
+            GUICtrlSetState($keep, $GUI_CHECKED) ; keep by default
+        EndIf
         
         ; Store control IDs
-        $gTreeItems($type & "_Parent")  = $parent
-        $gTreeItems($type & "_Keep")    = $keep
-        $gTreeItems($type & "_Sell")    = $sell
+        $gTreeItems($type & "_Parent") = $parent
         
         ; Defaults
-        GUICtrlSetState($parent, BitOR($GUI_CHECKED, $GUI_EXPAND))   ; pick up and expand by default
-        GUICtrlSetState($keep, $GUI_CHECKED)                         ; keep by default
+        GUICtrlSetState($parent, BitOR($GUI_CHECKED, $GUI_EXPAND)) ; pick up and expand by default
     Next
 EndFunc
 
@@ -109,15 +134,17 @@ Func LoadLootSettings()
             EndIf
             
             ; Set action
-            GUICtrlSetState($gTreeItems($type & "_Keep"), $GUI_UNCHECKED)
-            GUICtrlSetState($gTreeItems($type & "_Sell"), $GUI_UNCHECKED)
-            
-            Switch $action
-                Case "Keep"
-                    If $pickup Then GUICtrlSetState($gTreeItems($type & "_Keep"), $GUI_CHECKED)
-                Case "Sell"
-                    If $pickup Then GUICtrlSetState($gTreeItems($type & "_Sell"), $GUI_CHECKED)
-            EndSwitch
+            If $type <> "Pcons" And $type <> "Charr Bags" And $type <> "Charr Salvage Kit" Then
+                GUICtrlSetState($gTreeItems($type & "_Keep"), $GUI_UNCHECKED)
+                GUICtrlSetState($gTreeItems($type & "_Sell"), $GUI_UNCHECKED)
+                
+                Switch $action
+                    Case "Keep"
+                        If $pickup Then GUICtrlSetState($gTreeItems($type & "_Keep"), $GUI_CHECKED)
+                    Case "Sell"
+                        If $pickup Then GUICtrlSetState($gTreeItems($type & "_Sell"), $GUI_CHECKED)
+                EndSwitch
+            EndIf
         EndIf
     Next
 EndFunc
@@ -152,10 +179,12 @@ EndFunc
 ; =========================
 Func HandleType($type, $clickedID)
     Local $parent  = $gTreeItems($type & "_Parent")
+    Local $enabled = GUICtrlRead($parent) = $GUI_CHECKED
+    
+    If $type = "Pcons" Or $type = "Charr Bags" Or $type = "Charr Salvage Kit" Then Return
+    
     Local $keepID  = $gTreeItems($type & "_Keep")
     Local $sellID  = $gTreeItems($type & "_Sell")
-    
-    Local $enabled = GUICtrlRead($parent) = $GUI_CHECKED
     
     ; If type unchecked → clear children
     If Not $enabled Then
@@ -189,15 +218,18 @@ Func UpdateLootRules()
         Local $type = $gLootTypes[$i]
         
         Local $enabled = GUICtrlRead($gTreeItems($type & "_Parent")) = $GUI_CHECKED
-        Local $keep    = GUICtrlRead($gTreeItems($type & "_Keep")) = $GUI_CHECKED
-        Local $sell    = GUICtrlRead($gTreeItems($type & "_Sell")) = $GUI_CHECKED
         
         ; Save pickup state
         $LootRules($type & "_Pickup") = $enabled
         
         ; Save action
-        If $sell Then
-            $LootRules($type & "_Action") = "Sell"
+        If $type <> "Pcons" And $type <> "Charr Bags" And $type <> "Charr Salvage Kit" Then
+            Local $sell = GUICtrlRead($gTreeItems($type & "_Sell")) = $GUI_CHECKED
+            If $sell Then
+                $LootRules($type & "_Action") = "Sell"
+            Else
+                $LootRules($type & "_Action") = "Keep"
+            EndIf
         Else
             $LootRules($type & "_Action") = "Keep"
         EndIf

--- a/AscEnd/LootSettings.au3
+++ b/AscEnd/LootSettings.au3
@@ -28,17 +28,24 @@ Func ShowLootSettings()
     
     ; Create the GUI
     $hLootGUI = GUICreate("Loot Configuration", 320, 430)
-    GUISetFont(9, 400, 0, "Segoe UI")
-    GUISetBkColor(0xF5F5F5) ; Light modern background
+    GUISetFont(9, 400, 0, "Tahoma")
+    GUISetBkColor(0xF0F0F0) ; Standard grey background
     
     GUICtrlCreateLabel("Select items to pick up and their actions:", 15, 15, 290, 20)
-    GUICtrlSetFont(-1, 9, 600, 0, "Segoe UI") ; Bold header
+    GUICtrlSetFont(-1, 9, 600, 0, "Tahoma") ; Bold header
     
+    ; TVS_NOTOOLTIPS disables tooltips, removing TVS_SHOWSELALWAYS makes selection less prominent
     $tree = GUICtrlCreateTreeView(15, 40, 290, 330, _
-        BitOR($TVS_CHECKBOXES, $TVS_HASBUTTONS, $TVS_LINESATROOT, $TVS_SHOWSELALWAYS))
+        BitOR($TVS_CHECKBOXES, $TVS_HASBUTTONS, $TVS_LINESATROOT, $TVS_DISABLEDRAGDROP, $TVS_NOTOOLTIPS))
     
     $btnApply = GUICtrlCreateButton("Save & Apply", 125, 385, 95, 30)
     $btnClose = GUICtrlCreateButton("Close", 230, 385, 75, 30)
+    
+    ; Register OnEvent mode handlers if the main GUI uses OnEvent mode
+    GUISetOnEvent($GUI_EVENT_CLOSE, "HandleLootSettingsMsg", $hLootGUI)
+    GUICtrlSetOnEvent($btnApply, "HandleLootSettingsMsg")
+    GUICtrlSetOnEvent($btnClose, "HandleLootSettingsMsg")
+    GUICtrlSetOnEvent($tree, "HandleLootSettingsMsg")
     
     ; Build the tree
     BuildLootTree()
@@ -119,18 +126,20 @@ EndFunc
 ; HANDLE LOOT SETTINGS EVENTS
 ; =========================
 Func HandleLootSettingsMsg()
-    Local $msg = GUIGetMsg()
+    Local $ctrl = @GUI_CtrlId
     
-    Switch $msg
+    Switch $ctrl
         Case $GUI_EVENT_CLOSE, $btnClose
             GUISetState(@SW_HIDE, $hLootGUI)
             
         Case $tree
             ; Determine which node was clicked
-            Local $ctrl = @GUI_CtrlId
             For $i = 0 To UBound($gLootTypes) - 1
-                HandleType($gLootTypes[$i], $ctrl)
+                HandleType($gLootTypes[$i], GUICtrlRead($tree))
             Next
+            
+            ; Clear highlighting in treeview
+            GUICtrlSetState($tree, $GUI_FOCUS)
             
         Case $btnApply
             UpdateLootRules()
@@ -141,7 +150,7 @@ EndFunc
 ; =========================
 ; HANDLE TREEVIEW LOGIC
 ; =========================
-Func HandleType($type, $clickedCtrl)
+Func HandleType($type, $clickedID)
     Local $parent  = $gTreeItems($type & "_Parent")
     Local $keepID  = $gTreeItems($type & "_Keep")
     Local $sellID  = $gTreeItems($type & "_Sell")
@@ -156,7 +165,7 @@ Func HandleType($type, $clickedCtrl)
     EndIf
     
     ; Radio behaviour: only the clicked action stays checked
-    Switch $clickedCtrl
+    Switch $clickedID
         Case $keepID
             GUICtrlSetState($sellID, $GUI_UNCHECKED)
         Case $sellID

--- a/AscEnd/LootSettings.au3
+++ b/AscEnd/LootSettings.au3
@@ -179,7 +179,8 @@ EndFunc
 ; =========================
 Func HandleType($type, $clickedID)
     Local $parent  = $gTreeItems($type & "_Parent")
-    Local $enabled = GUICtrlRead($parent) = $GUI_CHECKED
+    Local $state = GUICtrlRead($parent)
+    Local $enabled = (BitAND($state, $GUI_CHECKED) = $GUI_CHECKED)
     
     If $type = "Pcons" Or $type = "Charr Bags" Or $type = "Charr Salvage Kit" Then Return
     
@@ -202,8 +203,11 @@ Func HandleType($type, $clickedID)
     EndSwitch
     
     ; Ensure at least one action is selected (default Keep)
-    If Not (GUICtrlRead($keepID) = $GUI_CHECKED _
-        Or GUICtrlRead($sellID) = $GUI_CHECKED) Then
+    Local $keepState = GUICtrlRead($keepID)
+    Local $sellState = GUICtrlRead($sellID)
+    
+    If Not ((BitAND($keepState, $GUI_CHECKED) = $GUI_CHECKED) _
+        Or (BitAND($sellState, $GUI_CHECKED) = $GUI_CHECKED)) Then
         GUICtrlSetState($keepID, $GUI_CHECKED)
     EndIf
 EndFunc
@@ -217,14 +221,17 @@ Func UpdateLootRules()
     For $i = 0 To UBound($gLootTypes) - 1
         Local $type = $gLootTypes[$i]
         
-        Local $enabled = GUICtrlRead($gTreeItems($type & "_Parent")) = $GUI_CHECKED
+        ; For TreeView Checkboxes, we must use BitAND with $GUI_CHECKED to properly read the state
+        Local $state = GUICtrlRead($gTreeItems($type & "_Parent"))
+        Local $enabled = (BitAND($state, $GUI_CHECKED) = $GUI_CHECKED)
         
         ; Save pickup state
         $LootRules($type & "_Pickup") = $enabled
         
         ; Save action
         If $type <> "Pcons" And $type <> "Charr Bags" And $type <> "Charr Salvage Kit" Then
-            Local $sell = GUICtrlRead($gTreeItems($type & "_Sell")) = $GUI_CHECKED
+            Local $sellState = GUICtrlRead($gTreeItems($type & "_Sell"))
+            Local $sell = (BitAND($sellState, $GUI_CHECKED) = $GUI_CHECKED)
             If $sell Then
                 $LootRules($type & "_Action") = "Sell"
             Else

--- a/AscEnd/LootSettings.au3
+++ b/AscEnd/LootSettings.au3
@@ -62,13 +62,11 @@ Func BuildLootTree()
         ; Children = Actions (radio style)
         Local $keep    = GUICtrlCreateTreeViewItem("Keep", $parent)
         Local $sell    = GUICtrlCreateTreeViewItem("Sell", $parent)
-        Local $salvage = GUICtrlCreateTreeViewItem("Salvage", $parent)
         
         ; Store control IDs
         $gTreeItems($type & "_Parent")  = $parent
         $gTreeItems($type & "_Keep")    = $keep
         $gTreeItems($type & "_Sell")    = $sell
-        $gTreeItems($type & "_Salvage") = $salvage
         
         ; Defaults
         GUICtrlSetState($parent, BitOR($GUI_CHECKED, $GUI_EXPAND))   ; pick up and expand by default
@@ -106,15 +104,12 @@ Func LoadLootSettings()
             ; Set action
             GUICtrlSetState($gTreeItems($type & "_Keep"), $GUI_UNCHECKED)
             GUICtrlSetState($gTreeItems($type & "_Sell"), $GUI_UNCHECKED)
-            GUICtrlSetState($gTreeItems($type & "_Salvage"), $GUI_UNCHECKED)
             
             Switch $action
                 Case "Keep"
                     If $pickup Then GUICtrlSetState($gTreeItems($type & "_Keep"), $GUI_CHECKED)
                 Case "Sell"
                     If $pickup Then GUICtrlSetState($gTreeItems($type & "_Sell"), $GUI_CHECKED)
-                Case "Salvage"
-                    If $pickup Then GUICtrlSetState($gTreeItems($type & "_Salvage"), $GUI_CHECKED)
             EndSwitch
         EndIf
     Next
@@ -150,7 +145,6 @@ Func HandleType($type, $clickedCtrl)
     Local $parent  = $gTreeItems($type & "_Parent")
     Local $keepID  = $gTreeItems($type & "_Keep")
     Local $sellID  = $gTreeItems($type & "_Sell")
-    Local $salvID  = $gTreeItems($type & "_Salvage")
     
     Local $enabled = GUICtrlRead($parent) = $GUI_CHECKED
     
@@ -158,7 +152,6 @@ Func HandleType($type, $clickedCtrl)
     If Not $enabled Then
         GUICtrlSetState($keepID, $GUI_UNCHECKED)
         GUICtrlSetState($sellID, $GUI_UNCHECKED)
-        GUICtrlSetState($salvID, $GUI_UNCHECKED)
         Return
     EndIf
     
@@ -166,19 +159,13 @@ Func HandleType($type, $clickedCtrl)
     Switch $clickedCtrl
         Case $keepID
             GUICtrlSetState($sellID, $GUI_UNCHECKED)
-            GUICtrlSetState($salvID, $GUI_UNCHECKED)
         Case $sellID
             GUICtrlSetState($keepID, $GUI_UNCHECKED)
-            GUICtrlSetState($salvID, $GUI_UNCHECKED)
-        Case $salvID
-            GUICtrlSetState($keepID, $GUI_UNCHECKED)
-            GUICtrlSetState($sellID, $GUI_UNCHECKED)
     EndSwitch
     
     ; Ensure at least one action is selected (default Keep)
     If Not (GUICtrlRead($keepID) = $GUI_CHECKED _
-        Or GUICtrlRead($sellID) = $GUI_CHECKED _
-        Or GUICtrlRead($salvID) = $GUI_CHECKED) Then
+        Or GUICtrlRead($sellID) = $GUI_CHECKED) Then
         GUICtrlSetState($keepID, $GUI_CHECKED)
     EndIf
 EndFunc
@@ -195,7 +182,6 @@ Func UpdateLootRules()
         Local $enabled = GUICtrlRead($gTreeItems($type & "_Parent")) = $GUI_CHECKED
         Local $keep    = GUICtrlRead($gTreeItems($type & "_Keep")) = $GUI_CHECKED
         Local $sell    = GUICtrlRead($gTreeItems($type & "_Sell")) = $GUI_CHECKED
-        Local $salvage = GUICtrlRead($gTreeItems($type & "_Salvage")) = $GUI_CHECKED
         
         ; Save pickup state
         $LootRules($type & "_Pickup") = $enabled
@@ -203,8 +189,6 @@ Func UpdateLootRules()
         ; Save action
         If $sell Then
             $LootRules($type & "_Action") = "Sell"
-        ElseIf $salvage Then
-            $LootRules($type & "_Action") = "Salvage"
         Else
             $LootRules($type & "_Action") = "Keep"
         EndIf

--- a/AscEnd/LootSettings.au3
+++ b/AscEnd/LootSettings.au3
@@ -248,9 +248,9 @@ Func UpdateLootRules()
         IniWrite($gLootIniFile, "LootSettings", $type & "_Action", $LootRules($type & "_Action"))
         
         ; Debug output
-        LogError($type & _
-            " | Pickup=" & $strPickup & _
-            " | Action=" & $LootRules($type & "_Action"))
+        LogStatus($type & _
+            " - Pickup = " & $strPickup & _
+            " - Action = " & $LootRules($type & "_Action"))
     Next
 EndFunc
 

--- a/AscEnd/LootSettings.au3
+++ b/AscEnd/LootSettings.au3
@@ -278,9 +278,9 @@ Func GetItemLootType($aItemPtr)
     
     ; Check for dyes first (ModelID 146)
     If $lModelID == 146 Then
-        If $lExtraID == 10 Then Return "DyeBlack"    ; Black dye
-        If $lExtraID == 12 Then Return "DyeWhite"    ; White dye
-        Return "DyeCustom"                           ; All other dyes
+        If $lExtraID == 10 Then Return "Black Dye"    ; Black dye
+        If $lExtraID == 12 Then Return "White Dye"    ; White dye
+        Return "Dye"                                  ; All other dyes
     EndIf
     
     ; Check rarity
@@ -288,49 +288,37 @@ Func GetItemLootType($aItemPtr)
     If $lRarity == $RARITY_Purple Then Return "Purple"
     If $lRarity == $RARITY_Gold Then Return "Gold"
     
+    If IsPcon($aItemPtr) Then Return "Pcons"
+
+    If IsPreCollectable($aItemPtr) Then
+        If $lModelID == 422 Then Return "Spider Legs"
+        If $lModelID == 423 Then Return "Charr Carvings"
+        If $lModelID == 424 Then Return "Icy Lodestones"
+        If $lModelID == 425 Then Return "Dull Carapaces"
+        If $lModelID == 426 Then Return "Gargoyle Skulls"
+        If $lModelID == 427 Then Return "Worn Belts"
+        If $lModelID == 428 Then Return "Unnatrual Seeds"
+        If $lModelID == 429 Then Return "Skale Fins"
+        If $lModelID == 430 Then Return "Skeletal Limbs"
+        If $lModelID == 431 Then Return "Enchanted Lodestones"
+        If $lModelID == 432 Then Return "Grawl Necklaces"
+        If $lModelID == 433 Then Return "Baked Husks"
+        If $lModelID == 2994 Then Return "Red Iris"
+        Return "Collectors"
+    EndIf
+
+    If $lModelID == 16453 Then Return "Charr Bags"
+    If $lModelID == 18721 Then Return "Charr Salvage Kit"
+        
     Return ""
 EndFunc
 
 Func CanPickUpEx($aItemPtr)
     Local $lModelID = Item_GetItemInfoByPtr($aItemPtr, "ModelID")
-    Local $aExtraID = Item_GetItemInfoByPtr($aItemPtr, "ExtraID")
-    Local $lRarity = Item_GetItemInfoByPtr($aItemPtr, "Rarity")
     
     ; Handle special cases first
-    If (($lModelID == 2511) And (GetGoldCharacter() < 99000)) Then
-        Return True	; gold coins
-    EndIf
-    
-    If $lModelID == $ITEM_ID_Lockpicks Then
-        Return True  ; Lockpicks
-    EndIf
-    
-    If $lModelID == 22269 Then	; Cupcakes
-        Return True
-    EndIf
-    
-    If $lModelID == $GC_I_MODELID_LUNAR_TOKEN Then ; Lunar Tokens
-        Return True
-    EndIf
-    
-    If $lModelID == $ExpertSalvKit Then
-        Return True
-    EndIf
-    
-    If IsPcon($aItemPtr) Then
-        Return True
-    EndIf
-    
-    If IsRareMaterial($aItemPtr) Then
-        Return False
-    EndIf
-    
-    If $lModelID == $CharrSalvKit Then
-        Return True
-    EndIf
-    
-    If $lModelID == 16453 Then
-        Return True
+    If (($lModelID == 2511) And (GetGoldCharacter() < 99000)) Then ; Always pickup coins
+        Return True	; Gold coins
     EndIf
     
     ; If it's in the tree we handle it here
@@ -347,25 +335,7 @@ Func CanPickUpEx($aItemPtr)
 EndFunc
 
 Func CanSellEx($aItemPtr)
-    Local $lModelID = Item_GetItemInfoByPtr($aItemPtr, "ModelID")
-    
-    ; Never sell special items
-    If $lModelID == $ITEM_ID_Lockpicks Then
-        Return False
-    EndIf
-    
-    If $lModelID == 22269 Then
-        Return False  ; Never sell cupcakes
-    EndIf
-    
-    If IsPcon($aItemPtr) Then
-        Return False
-    EndIf
-    
-    If IsRareMaterial($aItemPtr) Then
-        Return False
-    EndIf
-    
+
     ; Use loot system for classified items
     Local $itemType = GetItemLootType($aItemPtr)
     If $itemType <> "" Then

--- a/AscEnd/LootSettings.au3
+++ b/AscEnd/LootSettings.au3
@@ -32,7 +32,7 @@ Func ShowLootSettings()
     EndIf
     
     ; Create the GUI
-    $hLootGUI = GUICreate("AscEnd", 313, 288, 253, 250, -1, BitOR($WS_EX_TRANSPARENT,$WS_EX_WINDOWEDGE))
+    $hLootGUI = GUICreate("AscEnd", 313, 288, 253, 250, -1, BitOR($WS_EX_TRANSPARENT, $WS_EX_WINDOWEDGE, $WS_EX_TOPMOST))
     GUISetFont(9, 400, 0, "Tahoma")
     GUISetBkColor(0xF0F0F0) ; Standard grey background
     

--- a/AscEnd/LootSettings.au3
+++ b/AscEnd/LootSettings.au3
@@ -9,6 +9,7 @@
 Global $gLootTypes[3] = ["Purple", "Collector", "Mod"]
 Global $gTreeItems = ObjCreate("Scripting.Dictionary")
 Global $LootRules = ObjCreate("Scripting.Dictionary")
+Global $gLootIniFile = @ScriptDir & "\LootConfig.ini"
 
 Global $hLootGUI = 0
 Global $tree = 0
@@ -26,13 +27,18 @@ Func ShowLootSettings()
     EndIf
     
     ; Create the GUI
-    $hLootGUI = GUICreate("Loot Config", 320, 420)
+    $hLootGUI = GUICreate("Loot Configuration", 320, 430)
+    GUISetFont(9, 400, 0, "Segoe UI")
+    GUISetBkColor(0xF5F5F5) ; Light modern background
     
-    $tree = GUICtrlCreateTreeView(10, 10, 280, 320, _
-        BitOR($TVS_CHECKBOXES, $TVS_HASBUTTONS, $TVS_LINESATROOT))
+    GUICtrlCreateLabel("Select items to pick up and their actions:", 15, 15, 290, 20)
+    GUICtrlSetFont(-1, 9, 600, 0, "Segoe UI") ; Bold header
     
-    $btnApply = GUICtrlCreateButton("Apply", 10, 350, 80, 30)
-    $btnClose = GUICtrlCreateButton("Close", 100, 350, 80, 30)
+    $tree = GUICtrlCreateTreeView(15, 40, 290, 330, _
+        BitOR($TVS_CHECKBOXES, $TVS_HASBUTTONS, $TVS_LINESATROOT, $TVS_SHOWSELALWAYS))
+    
+    $btnApply = GUICtrlCreateButton("Save & Apply", 125, 385, 95, 30)
+    $btnClose = GUICtrlCreateButton("Close", 230, 385, 75, 30)
     
     ; Build the tree
     BuildLootTree()
@@ -65,8 +71,8 @@ Func BuildLootTree()
         $gTreeItems($type & "_Salvage") = $salvage
         
         ; Defaults
-        GUICtrlSetState($parent, $GUI_CHECKED)   ; pick up by default
-        GUICtrlSetState($keep, $GUI_CHECKED)     ; keep by default
+        GUICtrlSetState($parent, BitOR($GUI_CHECKED, $GUI_EXPAND))   ; pick up and expand by default
+        GUICtrlSetState($keep, $GUI_CHECKED)                         ; keep by default
     Next
 EndFunc
 
@@ -77,7 +83,15 @@ Func LoadLootSettings()
     For $i = 0 To UBound($gLootTypes) - 1
         Local $type = $gLootTypes[$i]
         
-        ; Check if we have saved settings
+        ; Read from INI file, default to True/Keep
+        Local $iniPickup = IniRead($gLootIniFile, "LootSettings", $type & "_Pickup", "True")
+        Local $iniAction = IniRead($gLootIniFile, "LootSettings", $type & "_Action", "Keep")
+        
+        ; Update dictionary
+        $LootRules($type & "_Pickup") = ($iniPickup = "True")
+        $LootRules($type & "_Action") = $iniAction
+        
+        ; Apply loaded settings to GUI
         If $LootRules.Exists($type & "_Pickup") Then
             Local $pickup = $LootRules($type & "_Pickup")
             Local $action = $LootRules($type & "_Action")
@@ -195,9 +209,15 @@ Func UpdateLootRules()
             $LootRules($type & "_Action") = "Keep"
         EndIf
         
+        ; Write to INI file
+        Local $strPickup = "False"
+        If $enabled Then $strPickup = "True"
+        IniWrite($gLootIniFile, "LootSettings", $type & "_Pickup", $strPickup)
+        IniWrite($gLootIniFile, "LootSettings", $type & "_Action", $LootRules($type & "_Action"))
+        
         ; Debug output
         LogError($type & _
-            " | Pickup=" & $LootRules($type & "_Pickup") & _
+            " | Pickup=" & $strPickup & _
             " | Action=" & $LootRules($type & "_Action"))
     Next
 EndFunc

--- a/AscEnd/LootSettings.au3
+++ b/AscEnd/LootSettings.au3
@@ -6,7 +6,7 @@
 ; =========================
 ; GLOBAL VARIABLES
 ; =========================
-Global $gLootTypes[24] = [ _
+Global $gLootTypes[23] = [ _
     "Gold", "Purple", "Blue", _
     "Collectors", "Baked Husks", "Charr Carvings", "Dull Carapaces", "Enchanted Lodestones", "Gargoyle Skulls", "Grawl Necklaces", "Icy Lodestones", "Red Iris", "Skale Fins", "Skeletal Limbs", "Spider Legs", "Unnatural Seeds", "Worn Belts", _
     "Dye", "Black Dye", "White Dye", _

--- a/AscEnd/LootSettings.au3
+++ b/AscEnd/LootSettings.au3
@@ -102,7 +102,7 @@ Func BuildLootTree()
         $gTreeItems($type & "_Parent") = $parent
         
         ; Defaults
-        GUICtrlSetState($parent, BitOR($GUI_CHECKED, $GUI_EXPAND)) ; pick up and expand by default
+        GUICtrlSetState($parent, $GUI_CHECKED) ; pick up by default
     Next
 EndFunc
 


### PR DESCRIPTION
This pull request introduces a major refactor and expansion of the loot configuration system in the AscEnd project. The old simple checkboxes for loot options (such as "Purple" and "Collectors") have been replaced with a comprehensive, category-based loot configuration GUI. This new system allows users to fine-tune which loot types to pick up and what action to take (keep or sell) for each type, with settings persisted in an INI file. Additionally, related code has been updated to use the new loot rules, and some minor fixes and improvements are included.

Key changes include:

**Loot Configuration System Overhaul:**

* Replaced the old "Purple" and "Collectors" checkboxes in `GUI.au3` with a "Loot Config" group and a "Settings" button, which opens a new loot configuration GUI. The loot options are now managed in a tree view with categories and sub-options, allowing for granular control over loot handling. (`AscEnd/GUI.au3`, [[1]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204L184-R190) [[2]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204L208-L215) [[3]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204L350-L359) [[4]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204L370-R355) [[5]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204R367-R369) [[6]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204L452-R439)
* The loot configuration GUI is implemented in `LootSettings.au3`, with a new structure for loot types, improved tree view logic, and persistent storage in `LootConfig.ini`. The system supports multiple categories (Gold, Purple, Blue, Collectors, Dyes, Pcons, etc.) and allows users to specify actions (Keep/Sell) per type. (`AscEnd/LootSettings.au3`, [[1]](diffhunk://#diff-fa373734299e030ac30d979d3f13a234f2c26852573530a7562caea759fa1494L9-R17) [[2]](diffhunk://#diff-fa373734299e030ac30d979d3f13a234f2c26852573530a7562caea759fa1494L29-R53) [[3]](diffhunk://#diff-fa373734299e030ac30d979d3f13a234f2c26852573530a7562caea759fa1494R68-L69) [[4]](diffhunk://#diff-fa373734299e030ac30d979d3f13a234f2c26852573530a7562caea759fa1494L80-R124) [[5]](diffhunk://#diff-fa373734299e030ac30d979d3f13a234f2c26852573530a7562caea759fa1494R137-R170) [[6]](diffhunk://#diff-fa373734299e030ac30d979d3f13a234f2c26852573530a7562caea759fa1494L135-R210) [[7]](diffhunk://#diff-fa373734299e030ac30d979d3f13a234f2c26852573530a7562caea759fa1494L181-R253) [[8]](diffhunk://#diff-fa373734299e030ac30d979d3f13a234f2c26852573530a7562caea759fa1494L229-R321)

**Integration with Loot Logic:**

* Updated loot decision logic throughout the codebase to use the new loot configuration system. For example, `CanSell` now checks the loot rules via `GetLootPickup`, and `Sell` uses `CanSellEx`. (`AscEnd/GwAu3_AddOns.au3`, [[1]](diffhunk://#diff-b79165ad0dd54bd9714b32a9e63601fbf849e254b3de6a99cc9f97589d0eef9cL2205-R2205) [[2]](diffhunk://#diff-b79165ad0dd54bd9714b32a9e63601fbf849e254b3de6a99cc9f97589d0eef9cL2300-R2305)
* Expanded the item type detection logic in `GetItemLootType` to recognize new categories and properly map items to loot rules. (`AscEnd/LootSettings.au3`, [AscEnd/LootSettings.au3L229-R321](diffhunk://#diff-fa373734299e030ac30d979d3f13a234f2c26852573530a7562caea759fa1494L229-R321))

**Removal of Deprecated Options and Variables:**

* Removed all references to the old "Purple" and "Collectors" options, including their constants, variables, and GUI controls. (`AscEnd/GUI.au3`, [[1]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204L184-R190) [[2]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204L208-L215) [[3]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204L350-L359) [[4]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204L370-R355) [[5]](diffhunk://#diff-958be432c43919f2a0308c1cba03c64f2f78a4979e83d2c72f2fcae5740e3204L452-R439); `AscEnd/GwAu3_AddOns.au3`, [[6]](diffhunk://#diff-b79165ad0dd54bd9714b32a9e63601fbf849e254b3de6a99cc9f97589d0eef9cL4244-L4245)

**Minor Fixes and Improvements:**

* Fixed an incorrect model ID in the Charr model list for `CharrCasterFilter`. (`AscEnd/GwAu3_AddOns.au3`, [AscEnd/GwAu3_AddOns.au3L1038-R1038](diffhunk://#diff-b79165ad0dd54bd9714b32a9e63601fbf849e254b3de6a99cc9f97589d0eef9cL1038-R1038))
* Added missing include for `LootSettings.au3` in the main script. (`AscEnd/AscEnd.au3`, [AscEnd/AscEnd.au3R4](diffhunk://#diff-69ecd99a6e267dbe509945879071b2ddda6b0fe47fa779420f732d34108f9abeR4))

This refactor significantly improves the flexibility and maintainability of loot handling in the bot, making it easier for users to customize their experience and for developers to extend loot logic in the future.